### PR TITLE
변수, 오브젝트, 배열 및 backtrace 정보를 파일 로그 형태로 남길 수 있는 함수

### DIFF
--- a/util/show_debug_msg.php
+++ b/util/show_debug_msg.php
@@ -6,3 +6,49 @@
 function show_debug_msg($msg) {
 	echo '<div style="padding: 5px; border: 1px solid #ccc; background-color: #eee;"><b>DEBUG: </b>'.$msg.'</div>';
 }
+if(!defined('DEBUG_FILE')) {
+	if(strpos(PHP_OS, "WIN")) {
+		define('DEBUG_FILE', 'c:\\debug.log');
+	} else {
+		define('DEBUG_FILE', '/tmp/debug.log');
+	}
+}
+
+function _write_log($msg) {
+		static $fd;
+		$old = umask(0);
+		if (!is_resource($fd)) $fd = fopen(DEBUG_FILE, 'a');
+		$msg = date('[Y-m-d H:i:s]') .' '. $msg ."\n";
+		fwrite($fd, $msg);
+		umask($old);
+}
+
+function debug_backtrace_log() {
+	$backtrace = debug_backtrace();
+	ob_start();
+	echo "\n";
+	for($i=1;$i<count($backtrace);$i++) {
+		echo $backtrace[$i]['file'].', line:'.$backtrace[$i]['line'].", function:".$backtrace[$i]['function']."\n";
+		var_dump($backtrace[$i]['args']);
+	}
+	$trace = ob_get_contents();
+	ob_end_clean();
+	_write_log($trace);
+}
+
+function debug_log ($msg) {
+	if ( is_array($msg) || is_object($msg) ) {
+		debug_object_log($msg);
+	}
+	else {
+		_write_log($msg);
+	}
+}
+
+function debug_object_log ($obj) {
+	ob_start();
+	print_r($obj);
+	$msg = ob_get_contents();
+	ob_end_clean();
+	_write_log($msg);
+}


### PR DESCRIPTION
개인적으로 개발할 때 유용하게 사용하고 있어 공유 차원에서 pull request 합니다.
특히 개발서버와 실서버의 환경이 다를 때, 실 DB의 데이터를 개발DB로 옮기기 난감할 때
특정 유저에게만 문제가 발생할 때 등 메시지를 서비스에 직접 노출 하지 않아도 되기 때문에 유용했습니다.

